### PR TITLE
Fixed unzipping of OpenTrack archives, which was broken by the previous commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Then in Steam, right-click the game you want to use opentrack with, click on `Pr
 opentrack-launcher %command%
 
 # If you installed the script with the non-root option:
-/home/<your-username>/.local/bin/opentrack-launcher %command%
+~/.local/bin/opentrack-launcher %command%
 ```
 
 The first time you run the game with the launcher it might take a while, since it will download the latest version of opentrack and generate the launch script for the game.

--- a/opentrack-launcher
+++ b/opentrack-launcher
@@ -60,6 +60,11 @@ def isnewer(ver):
         f.close()
         return newer
 
+def removeversionfile():
+    versionfile = join(LAUNCHERHOME, "version.txt")
+    if isfile(versionfile):
+        remove(versionfile)
+
 def dlopentrack():
     info("checking if opentrack is up to date...")
     try:
@@ -92,16 +97,23 @@ def dlopentrack():
                     info("removing old opentrack version...")
                     rmtree(opentrackinstall)
                 info("extracting downloaded opentrack archive...")
-                err = Popen([ which(ZIPBINARY), "x", "-aoa", "-o" + LAUNCHERHOME, opentrackark ], cwd=LAUNCHERHOME).wait()
-                remove(opentrackark)
-                if err != 0:
-                    panic("failed to extract " + opentrackark + "; 7z exit code: " + str(err))
+                try:
+                    err = Popen([ which(ZIPBINARY), "x", "-aoa", "-o" + LAUNCHERHOME, opentrackark ], cwd=LAUNCHERHOME).wait()
+                    remove(opentrackark)
+                    if err != 0:
+                        panic("failed to extract " + opentrackark + "; 7z exit code: " + str(err))
+                except:
+                    # avoid unzip failure leaving files in a state where the launcher will never work again
+                    removeversionfile()
+                    remove(opentrackark)
+                    raise
                 return
 
 def getopentrack():
     dlopentrack()
     opentrackexec = join(LAUNCHERHOME, "install/opentrack.exe")
     if not isfile(opentrackexec):
+        removeversionfile()	# force next call of launcher to try to downloading OpenTrack again
         panic("could not find " + opentrackexec)
     else:
         return opentrackexec

--- a/opentrack-launcher
+++ b/opentrack-launcher
@@ -150,6 +150,7 @@ def makehome():
             panic("failed to create opentrack-launcher home: " + LAUNCHERHOME)
 
 def check7z():
+    global ZIPBINARY
     if not which("7z") is None:
         ZIPBINARY = "7z"
     elif not which("7za") is None:


### PR DESCRIPTION
This fixes the code added by the last commit ("Added basic support for fedora by checking for the 7za binary"), which broke unzipping of OpenTrack archives, due to a missing "global" declaration.  (The lack of "global" meant ZIPBINARY was read as an empty string by dlopentrack(), so that unzipping the OpenTrack archive failed.)  I assume the author didn't notice this because there hasn't been a new OpenTrack release since then.

I also added handling of failed unzipping, as previously this would leave the files in a state where the launcher would consistently fail to start (due to the presence of a version.txt file but there being no corresponding OpenTrack executable).  And if it still somehow ends-up in that state, it now auto-deletes the version.txt file, so that the next launch will still try downloading & unpacking OpenTrack again.

Finally I made a minor change to the README to replace `/home/<your-username>/` with `~/` (which is easier & less error prone).

And yes, all these changes have been tested as actually working!