### PR TITLE
Run python with /usr/bin/env

### DIFF
--- a/opentrack-launcher
+++ b/opentrack-launcher
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 from os.path import join, isfile, isdir, abspath
 from os import makedirs, mkdir, environ, remove


### PR DESCRIPTION
Running python interpreter with absolute path was causing problems on my NixOS, so here's a PR with changes it to running python via `env`, which should work better across different systems as it's not making assumptions about system's python location 