### PR TITLE
Bug fixes for updating Opentrack

### DIFF
--- a/opentrack-launcher
+++ b/opentrack-launcher
@@ -10,14 +10,14 @@ from subprocess import Popen
 import json
 
 def panic(msg):
-    print("[opentrack-launcher] CRITICAL:", msg)
+    print("[opentrack-launcher] CRITICAL:", msg, flush=True)
     exit(-1)
 
 def error(msg):
-    print("[opentrack-launcher] ERROR:", msg)
+    print("[opentrack-launcher] ERROR:", msg, flush=True)
 
 def info(msg):
-    print("[opentrack-launcher] INFO:", msg)
+    print("[opentrack-launcher] INFO:", msg, flush=True)
 
 def getenv(name):
     try:

--- a/opentrack-launcher
+++ b/opentrack-launcher
@@ -56,6 +56,7 @@ def isnewer(ver):
         newer = fver != ver
         if newer:
             f.truncate(0)
+            f.seek(0)
             f.write(ver)
         f.close()
         return newer

--- a/opentrack-launcher
+++ b/opentrack-launcher
@@ -54,12 +54,14 @@ def isnewer(ver):
     with open(versionfile, mode="r+") as f:
         fver = f.read()
         newer = fver != ver
-        if newer:
-            f.truncate(0)
-            f.seek(0)
-            f.write(ver)
         f.close()
         return newer
+
+def updateversionfile(ver):
+    versionfile = join(LAUNCHERHOME, "version.txt")
+    with open(versionfile, mode="w") as f:
+        f.write(ver)
+    f.close()
 
 def removeversionfile():
     versionfile = join(LAUNCHERHOME, "version.txt")
@@ -103,12 +105,14 @@ def dlopentrack():
                     remove(opentrackark)
                     if err != 0:
                         panic("failed to extract " + opentrackark + "; 7z exit code: " + str(err))
+                        return
                 except:
                     # avoid unzip failure leaving files in a state where the launcher will never work again
                     removeversionfile()
                     remove(opentrackark)
                     raise
-                return
+    updateversionfile(version)
+    return
 
 def getopentrack():
     dlopentrack()


### PR DESCRIPTION
More details about my commits:
* **Fix garbage being written to version.txt** - I noticed that Opentrack Launcher was downloading & installing Opentrack *every* time it was started, because "version.txt" started with many null characters.  This fixes the bug, by seeking to the start of the file after truncating it, but before writing the new version string.
* **Prevent failed download/update of Opentrack never trying to update to same version again** - While experimenting with making Opentrack Launcher download/install Opentrack, I noticed that it wrote the new "version.txt" before actually downloading/installing Opentrack, and so even if that failed (say due to an internet issue) it would never attempt to re-download the same version - meaning users could be left with a non-working Opentrack.  I guess this bug was hidden by the earlier bug that caused it to download everytime.  (This fix also happens to remove the code that was updated by the earlier fix.)
* **Print immediately for better debugging, don't wait until Python script finishes** - I noticed that Opentrack Launcher's terminal output does not appear until I closed the game being run (and presumably Opentrack Launcher finished).  This was due to Python buffering the output, so I forced it to output immediately, which should make debugging easier.